### PR TITLE
Full Width Layout: Resolve pre-PHP 5.5 empty() fatal error

### DIFF
--- a/page-full-no-title.php
+++ b/page-full-no-title.php
@@ -14,9 +14,11 @@ get_header(); the_post(); ?>
 
 	<div id="primary" class="content-area">
 
-		<?php $page_header = get_post_meta( get_the_ID(), 'focus-page-header', true );
-
-		if ( isset( $page_header ) && $page_header && !empty( get_post_meta( get_the_ID(), 'panels_data', true ) ) ) {
+		<?php
+		$page_header = get_post_meta( get_the_ID(), 'focus-page-header', true );
+		$page_builder_data = get_post_meta( get_the_ID(), 'panels_data', true );
+		
+		if ( isset( $page_header ) && $page_header && !empty( $page_builder_data ) ) {
 
 			$panels_data = get_post_meta( get_the_ID(), 'panels_data', true );
 


### PR DESCRIPTION
PHP prior to 5.5, empty didn't allow functions that returned a value. I was able to replicate this issue on two  5.4 websites. Exact error message being:

> Fatal error: Can't use function return value in write context in /home/tlims4eisnw2/public_html/wp-content/themes/focus/page-full-no-title.php on line 19