### PR TITLE
Infinite Scroll - posts per page global and filter

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -84,12 +84,14 @@ add_filter('wp_title', 'focus_wp_title', 10, 3);
 /**
  * Adds support for Jetpack's Infinite Scroll.
  */
- function focus_infinite_scroll_init() {
-	 add_theme_support( 'infinite-scroll', array(
-		'container' => 'main-loop',
-		'render' => 'focus_infinite_scroll_render',
-		'footer' => 'page',
+function focus_infinite_scroll_init() {
+	add_theme_support( 'infinite-scroll', array(
+		'container'      => 'main-loop',
+		'render'         => 'focus_infinite_scroll_render',
+		'footer'         => 'page',
+		'posts_per_page' => apply_filters( 'focus_infinite_scroll_count', get_option( 'posts_per_page' ) ),
 	) );
+}) );
 }
 add_action( 'init', 'focus_infinite_scroll_init' );
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -91,7 +91,6 @@ function focus_infinite_scroll_init() {
 		'footer'         => 'page',
 		'posts_per_page' => apply_filters( 'focus_infinite_scroll_count', get_option( 'posts_per_page' ) ),
 	) );
-}) );
 }
 add_action( 'init', 'focus_infinite_scroll_init' );
 


### PR DESCRIPTION
The default posts per page for infinite scroll is 7 posts - which doesn't really work for the Thumbnail Grid. As such, we should pull the WordPress posts per page and add a filter for users to override it if desired.