### PR TITLE
Corrected category_description issue

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -16,9 +16,9 @@ get_header(); ?>
 				</h2>
 
 				<?php if ( is_category() ) : ?>
-					<p class="category-description">
+					<div class="category-description">
 						<?php echo category_description(); ?>
-					</p>
+					</div>
 				<?php endif; ?>
 
 				<?php get_template_part('loop') ?>

--- a/archive.php
+++ b/archive.php
@@ -11,15 +11,12 @@ get_header(); ?>
 
 			<div class="container">
 
-				<h2 class="archive-title">
-					<?php wp_title(' ') ?>
-				</h2>
-
-				<?php if ( is_category() ) : ?>
-					<div class="category-description">
-						<?php echo category_description(); ?>
-					</div>
-				<?php endif; ?>
+				<header class="page-header">
+					<?php
+					the_archive_title( '<h2 class="archive-title">', '</h1>' );
+					the_archive_description( '<div class="category-description archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
 
 				<?php get_template_part('loop') ?>
 


### PR DESCRIPTION
wpautop is run on category_description() so it'll break the exisiting paragraph.

@Misplon What are your thoughts on making it more like [North's one](https://github.com/siteorigin/siteorigin-north/blob/develop/archive.php#L19)? As currently, only category descriptions will be output.

![](https://i.imgur.com/HZJWudI.png)