### PR TITLE
Prevent blank content areas from appearing

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -13,7 +13,7 @@
 
 	<?php do_action('before_footer'); ?>
 
-	<footer id="colophon" class="site-footer" role="contentinfo">
+	<footer id="colophon" class="site-footer<?php if ( is_single() && ! focus_display_content_area() ) echo ' no-content'; ?>" role="contentinfo">
 		<div class="container">
 			<div id="footer-widgets">
 				<?php dynamic_sidebar('sidebar-footer') ?>

--- a/footer.php
+++ b/footer.php
@@ -13,7 +13,7 @@
 
 	<?php do_action('before_footer'); ?>
 
-	<footer id="colophon" class="site-footer<?php if ( is_single() && ! focus_display_content_area() ) echo ' no-content'; ?>" role="contentinfo">
+	<footer id="colophon" class="site-footer<?php if ( is_singular() && ! focus_display_content_area() ) echo ' no-content'; ?>" role="contentinfo">
 		<div class="container">
 			<div id="footer-widgets">
 				<?php dynamic_sidebar('sidebar-footer') ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -297,3 +297,16 @@ function focus_replace_panels_data( $data, $post_id ){
 	return $data;
 }
 add_filter( 'siteorigin_panels_data', 'focus_replace_panels_data', 10, 2 );
+
+/**
+ * Check if content area needs to be displayed
+ *
+ * It'll only ever not be displayed if there's no content, there's a video, the author isn't shown, the sidebar doesn't have any widgets and comments are disabled.
+ */ 
+function focus_display_content_area() {
+	if( ! ( empty( get_the_content() ) && focus_post_has_video() && !siteorigin_setting( 'general_display_author' ) && !is_active_sidebar( 'sidebar-' . ( is_page() ? 'page' : 'post') ) && !comments_open() ) ){
+		return true;
+	}else{
+		return false;
+	}
+}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -304,9 +304,10 @@ add_filter( 'siteorigin_panels_data', 'focus_replace_panels_data', 10, 2 );
  * It'll only ever not be displayed if there's no content, there's a video, the author isn't shown, the sidebar doesn't have any widgets and comments are disabled.
  */ 
 function focus_display_content_area() {
-	if( ! ( empty( get_the_content() ) && focus_post_has_video() && !siteorigin_setting( 'general_display_author' ) && !is_active_sidebar( 'sidebar-' . ( is_page() ? 'page' : 'post') ) && !comments_open() ) ){
+	$the_content = get_the_content();
+	if ( ! ( empty( $the_content ) && focus_post_has_video() && !siteorigin_setting( 'general_display_author' ) && !is_active_sidebar( 'sidebar-' . ( is_page() ? 'page' : 'post') ) && !comments_open() ) ) {
 		return true;
-	}else{
+	} else {
 		return false;
 	}
 }

--- a/page-full-no-title.php
+++ b/page-full-no-title.php
@@ -34,7 +34,7 @@ get_header(); the_post(); ?>
 			}
 			echo '<div id="single-header">' . ob_get_clean() . '</div>';
 		} ?>
-		<?php if ( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ) : ?>
 			<div class="container">
 				<div class="container-decoration"></div>
 

--- a/page-full-no-title.php
+++ b/page-full-no-title.php
@@ -34,7 +34,7 @@ get_header(); the_post(); ?>
 			}
 			echo '<div id="single-header">' . ob_get_clean() . '</div>';
 		} ?>
-		<?php if( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ): ?>
 			<div class="container">
 				<div class="container-decoration"></div>
 

--- a/page-full-no-title.php
+++ b/page-full-no-title.php
@@ -34,27 +34,28 @@ get_header(); the_post(); ?>
 			}
 			echo '<div id="single-header">' . ob_get_clean() . '</div>';
 		} ?>
+		<?php if( focus_display_content_area() ): ?>
+			<div class="container">
+				<div class="container-decoration"></div>
 
-		<div class="container">
-			<div class="container-decoration"></div>
+				<div class="content-container">
+					<div id="content" class="site-content" role="main">
 
-			<div class="content-container">
-				<div id="content" class="site-content" role="main">
+						<div class="entry-content">
+							<?php the_content() ?>
+						</div>
 
-					<div class="entry-content">
-						<?php the_content() ?>
-					</div>
+						<?php
+						// If comments are open or we have at least one comment, load up the comment template
+						if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
+						?>
+					</div><!-- #content .site-content.content-container -->
 
-					<?php
-					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
-					?>
-				</div><!-- #content .site-content.content-container -->
+					<div class="clear"></div>
+				</div>
 
-				<div class="clear"></div>
 			</div>
-
-		</div>
+		<?php endif; ?>
 	</div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/page-full.php
+++ b/page-full.php
@@ -33,7 +33,7 @@ get_header(); the_post(); ?>
 				<?php endif; ?>
 			</div>
 		</div>
-		<?php if ( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ) : ?>
 			<div class="container">
 				<div class="container-decoration"></div>
 

--- a/page-full.php
+++ b/page-full.php
@@ -33,7 +33,7 @@ get_header(); the_post(); ?>
 				<?php endif; ?>
 			</div>
 		</div>
-		<?php if( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ): ?>
 			<div class="container">
 				<div class="container-decoration"></div>
 

--- a/page-full.php
+++ b/page-full.php
@@ -33,27 +33,28 @@ get_header(); the_post(); ?>
 				<?php endif; ?>
 			</div>
 		</div>
+		<?php if( focus_display_content_area() ): ?>
+			<div class="container">
+				<div class="container-decoration"></div>
 
-		<div class="container">
-			<div class="container-decoration"></div>
+				<div class="content-container">
+					<div id="content" class="site-content" role="main">
 
-			<div class="content-container">
-				<div id="content" class="site-content" role="main">
+						<div class="entry-content">
+							<?php the_content() ?>
+						</div>
 
-					<div class="entry-content">
-						<?php the_content() ?>
-					</div>
+						<?php
+						// If comments are open or we have at least one comment, load up the comment template
+						if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
+						?>
+					</div><!-- #content .site-content.content-container -->
 
-					<?php
-					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
-					?>
-				</div><!-- #content .site-content.content-container -->
+					<div class="clear"></div>
+				</div>
 
-				<div class="clear"></div>
 			</div>
-
-		</div>
+		<?php endif; ?>
 	</div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -30,32 +30,33 @@ get_header(); the_post(); ?>
 			<?php endif; ?>
 		</div>
 	</div>
+	<?php if( focus_display_content_area() ): ?>
+		<div class="container">
+			<div class="container-decoration"></div>
 
-	<div class="container">
-		<div class="container-decoration"></div>
+			<div class="content-container">
+				<div id="content" class="site-content" role="main">
 
-		<div class="content-container">
-			<div id="content" class="site-content" role="main">
+					<div class="entry-content">
+						<?php the_content() ?>
+					</div>
 
-				<div class="entry-content">
-					<?php the_content() ?>
-				</div>
+					<div class="clear"></div>
+					<?php wp_link_pages() ?>
+
+					<?php
+					// If comments are open or we have at least one comment, load up the comment template
+					if ( ( comments_open() || '0' != get_comments_number() ) && !siteorigin_setting( 'comments_page_hide' ) ) comments_template( '', true );
+					?>
+				</div><!-- #content .site-content.content-container -->
+
+				<?php get_sidebar(); ?>
 
 				<div class="clear"></div>
-				<?php wp_link_pages() ?>
+			</div>
 
-				<?php
-				// If comments are open or we have at least one comment, load up the comment template
-				if ( ( comments_open() || '0' != get_comments_number() ) && !siteorigin_setting( 'comments_page_hide' ) ) comments_template( '', true );
-				?>
-			</div><!-- #content .site-content.content-container -->
-
-			<?php get_sidebar(); ?>
-
-			<div class="clear"></div>
 		</div>
-
-	</div>
+	<?php endif; ?>
 </div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -30,7 +30,7 @@ get_header(); the_post(); ?>
 			<?php endif; ?>
 		</div>
 	</div>
-	<?php if( focus_display_content_area() ): ?>
+	<?php if ( focus_display_content_area() ): ?>
 		<div class="container">
 			<div class="container-decoration"></div>
 

--- a/page.php
+++ b/page.php
@@ -30,7 +30,7 @@ get_header(); the_post(); ?>
 			<?php endif; ?>
 		</div>
 	</div>
-	<?php if ( focus_display_content_area() ): ?>
+	<?php if ( focus_display_content_area() ) : ?>
 		<div class="container">
 			<div class="container-decoration"></div>
 

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1442,6 +1442,10 @@ h2.archive-title {
 	margin-top: 25px;
 	background: #2A2B2F;
 	padding: 25px 0;
+
+	&.no-content {
+	margin-top: 0;
+	}
 }
 
 /**

--- a/single.php
+++ b/single.php
@@ -45,7 +45,7 @@ get_header(); the_post(); ?>
 	<div class="container">
 		<div class="container-decoration"></div>
 
-		<?php if ( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ) : ?>
 			<div class="content-container">
 				<div id="content" class="site-content" role="main">
 

--- a/single.php
+++ b/single.php
@@ -41,10 +41,11 @@ get_header(); the_post(); ?>
 			<?php endif; ?>
 		</div>
 	</div>
-	<?php if( focus_display_content_area() ): ?>
-		<div class="container">
-			<div class="container-decoration"></div>
+	
+	<div class="container">
+		<div class="container-decoration"></div>
 
+		<?php if( focus_display_content_area() ): ?>
 			<div class="content-container">
 				<div id="content" class="site-content" role="main">
 
@@ -65,9 +66,9 @@ get_header(); the_post(); ?>
 
 				<div class="clear"></div>
 			</div>
-			<?php if( siteorigin_setting('general_posts_nav') ) focus_content_nav('posts-nav') ?>
-		</div>
-	<?php endif; ?>
+		<?php endif; ?>
+		<?php if( siteorigin_setting('general_posts_nav') ) focus_content_nav('posts-nav') ?>
+	</div>
 </div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -45,7 +45,7 @@ get_header(); the_post(); ?>
 	<div class="container">
 		<div class="container-decoration"></div>
 
-		<?php if( focus_display_content_area() ): ?>
+		<?php if ( focus_display_content_area() ): ?>
 			<div class="content-container">
 				<div id="content" class="site-content" role="main">
 

--- a/single.php
+++ b/single.php
@@ -41,32 +41,33 @@ get_header(); the_post(); ?>
 			<?php endif; ?>
 		</div>
 	</div>
+	<?php if( focus_display_content_area() ): ?>
+		<div class="container">
+			<div class="container-decoration"></div>
 
-	<div class="container">
-		<div class="container-decoration"></div>
+			<div class="content-container">
+				<div id="content" class="site-content" role="main">
 
-		<div class="content-container">
-			<div id="content" class="site-content" role="main">
+					<div class="entry-content">
+						<?php the_content() ?>
+						<?php wp_link_pages(array('before' => '<div class="clear"></div>'.'<p>' . __('Pages:', 'focus'))) ?>
+					</div>
 
-				<div class="entry-content">
-					<?php the_content() ?>
-					<?php wp_link_pages(array('before' => '<div class="clear"></div>'.'<p>' . __('Pages:', 'focus'))) ?>
-				</div>
+					<div class="clear"></div>
+
+					<?php
+						// If comments are open or we have at least one comment, load up the comment template
+						if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
+					?>
+				</div><!-- #content .site-content.content-container -->
+
+				<?php get_sidebar(); ?>
 
 				<div class="clear"></div>
-
-				<?php
-					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || '0' != get_comments_number() ) comments_template( '', true );
-				?>
-			</div><!-- #content .site-content.content-container -->
-
-			<?php get_sidebar(); ?>
-
-			<div class="clear"></div>
+			</div>
+			<?php if( siteorigin_setting('general_posts_nav') ) focus_content_nav('posts-nav') ?>
 		</div>
-		<?php if( siteorigin_setting('general_posts_nav') ) focus_content_nav('posts-nav') ?>
-	</div>
+	<?php endif; ?>
 </div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -42,10 +42,10 @@ get_header(); the_post(); ?>
 		</div>
 	</div>
 	
+	<?php if ( focus_display_content_area() ) : ?>
 	<div class="container">
 		<div class="container-decoration"></div>
 
-		<?php if ( focus_display_content_area() ) : ?>
 			<div class="content-container">
 				<div id="content" class="site-content" role="main">
 
@@ -66,9 +66,9 @@ get_header(); the_post(); ?>
 
 				<div class="clear"></div>
 			</div>
-		<?php endif; ?>
 		<?php if( siteorigin_setting('general_posts_nav') ) focus_content_nav('posts-nav') ?>
 	</div>
+	<?php endif; ?>
 </div><!-- #primary .content-area -->
 
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1150,6 +1150,8 @@ h2.archive-title {
   margin-top: 25px;
   background: #2A2B2F;
   padding: 25px 0; }
+  .site-footer.no-content {
+    margin-top: 0; }
 
 /**
  * #.# Call To Action


### PR DESCRIPTION
This PR adds focus_display_content_area() which prevents situations where this happens:

![](https://i.imgur.com/CXGTnLA.png)

The above occurs when there's no content, the author isn't set to be shown, the sidebar doesn't have any widgets and comments are disabled. This will prevent it and the regular content if any of the things I listed aren't the case.